### PR TITLE
style: improve map layout and bottom navigation

### DIFF
--- a/app/(app)/map/page.tsx
+++ b/app/(app)/map/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 import dynamic from "next/dynamic";
-const MapCanvas = dynamic(() => import("../../../components/map/MapCanvas"), { ssr: false });
+const MapCanvas = dynamic(() => import("../../../components/map/MapCanvas"), {
+  ssr: false,
+});
 
 export default function MapPage() {
-  return <main className="w-screen h-screen"><MapCanvas /></main>;
+  return <MapCanvas />;
 }
 

--- a/app/api/map/search/route.ts
+++ b/app/api/map/search/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
-import { cookies, headers } from "next/headers";
-import { getTimeWindowSQL } from "@/lib/geo";
+import { cookies } from "next/headers";
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -9,7 +8,7 @@ export async function GET(req: Request) {
   const minLat = parseFloat(searchParams.get("minLat") || "");
   const maxLng = parseFloat(searchParams.get("maxLng") || "");
   const maxLat = parseFloat(searchParams.get("maxLat") || "");
-  const when = (searchParams.get("when") || "now") as "now" | "today" | "weekend";
+  const when = (searchParams.get("when") || "today") as "today" | "weekend" | "month";
 
   if ([minLng, minLat, maxLng, maxLat].some(Number.isNaN)) {
     return NextResponse.json({ error: "Invalid bbox" }, { status: 400 });
@@ -21,8 +20,6 @@ export async function GET(req: Request) {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     { cookies: { get: (name) => cookieStore.get(name)?.value } }
   );
-
-  const timeSQL = getTimeWindowSQL(when);
 
   // Query via RPC to keep SQL clean (recommended), but inline SQL via a view also works.
   // Here we use a SQL string in a single call with filters.

--- a/components/map/MapCanvas.tsx
+++ b/components/map/MapCanvas.tsx
@@ -11,7 +11,7 @@ import { createPinPopupContent } from "./PinPopup";
 export default function MapCanvas() {
   const mapRef = useRef<maplibregl.Map | null>(null);
   const markersRef = useRef<maplibregl.Marker[]>([]);
-  const [when, setWhen] = useState<WhenFilter>("now");
+  const [when, setWhen] = useState<WhenFilter>("today");
 
   useEffect(() => {
     const map = new maplibregl.Map({
@@ -93,11 +93,11 @@ export default function MapCanvas() {
   }, [when]);
 
   return (
-    <div className="w-full h-full relative">
+    <div className="relative w-full">
       <div className="absolute top-3 left-3 z-10">
         <MapFilters value={when} onChange={setWhen} />
       </div>
-      <div id="map" className="h-[calc(100dvh-120px)] w-full" />
+      <div id="map" className="h-[calc(100dvh-64px)] w-full" />
     </div>
   );
 }

--- a/components/map/MapFilters.tsx
+++ b/components/map/MapFilters.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 
-export type WhenFilter = "now" | "today" | "weekend";
+export type WhenFilter = "today" | "weekend" | "month";
 
 type Props = {
   value: WhenFilter;
@@ -13,9 +13,9 @@ type Props = {
 export default function MapFilters({ value, onChange, className }: Props) {
   const items: { key: WhenFilter; label: string }[] = useMemo(
     () => [
-      { key: "now", label: "Now" },
       { key: "today", label: "Today" },
       { key: "weekend", label: "Weekend" },
+      { key: "month", label: "This Month" },
     ],
     []
   );
@@ -24,8 +24,9 @@ export default function MapFilters({ value, onChange, className }: Props) {
     <div
       role="tablist"
       aria-label="Time filter"
-      className={`bg-white/90 rounded-xl shadow border flex items-center gap-1 p-1 ${className ?? ""}`}
+      className={`flex items-center gap-2 rounded-full border bg-white/90 p-1 shadow ${className ?? ""}`}
     >
+      <span className="px-2 text-xs text-gray-600">Time:</span>
       {items.map((it) => {
         const active = value === it.key;
         return (
@@ -34,8 +35,8 @@ export default function MapFilters({ value, onChange, className }: Props) {
             role="tab"
             aria-selected={active}
             onClick={() => onChange(it.key)}
-            className={`px-2 py-1 rounded text-sm transition
-              ${active ? "bg-black text-white" : "bg-white hover:bg-gray-100 border"}`}
+            className={`rounded-full px-2 py-1 text-xs transition
+              ${active ? "bg-black text-white" : "bg-white text-gray-700 hover:bg-gray-100"}`}
           >
             {it.label}
           </button>

--- a/components/nav/BottomNav.tsx
+++ b/components/nav/BottomNav.tsx
@@ -19,17 +19,17 @@ export default function BottomNav() {
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       {/* list-none prevents browser bullets when Tailwind is live */}
-      <ul className="mx-auto grid max-w-md grid-cols-3 list-none">
+      <ul className="grid w-full grid-cols-3 list-none">
         {TABS.map(({ href, label, Icon }) => {
           const active = pathname === href || pathname?.startsWith(href + "/");
           return (
             <li key={href}>
               <Link
                 href={href}
-                className={`flex flex-col items-center py-2 text-xs ${active ? "text-black" : "text-gray-500"}`}
+                className={`flex flex-col items-center justify-center py-2 text-xs ${active ? "text-black" : "text-gray-500"}`}
                 aria-current={active ? "page" : undefined}
               >
-                <Icon size={22} />
+                <Icon size={24} />
                 <span>{label}</span>
               </Link>
             </li>

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -11,13 +11,13 @@ export function normalizeBbox(minLng: number, minLat: number, maxLng: number, ma
   };
 }
 
-export function getTimeWindowSQL(where: "now" | "today" | "weekend") {
+export function getTimeWindowSQL(where: "today" | "weekend" | "month") {
   switch (where) {
-    case "now":
-      return "tstzrange(e.starts_at, e.ends_at, '[]') @> now()";
     case "today":
       return "e.starts_at::date = now()::date";
     case "weekend":
       return "EXTRACT(ISODOW FROM e.starts_at) IN (6,7)"; // Sat/Sun
+    case "month":
+      return "date_trunc('month', e.starts_at) = date_trunc('month', now())";
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,4 +10,4 @@ export type EventPin = {
   address: string | null;
 };
 
-export type WhenFilter = "now" | "today" | "weekend";
+export type WhenFilter = "today" | "weekend" | "month";


### PR DESCRIPTION
## Summary
- center and enlarge BottomNav to span full width
- remove map page fullscreen wrapper and adjust map height
- streamline map filters with "Today", "Weekend", "This Month" options
- support new `month` time filter in API utilities

## Testing
- `npm run lint` *(fails: existing errors in unrelated files)*
- `npx eslint components/nav/BottomNav.tsx components/map/MapCanvas.tsx components/map/MapFilters.tsx lib/geo.ts lib/types.ts 'app/(app)/map/page.tsx' app/api/map/search/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b74a3dbe80832d87e5266318ea5cf2